### PR TITLE
Fixed nntp Message Posting

### DIFF
--- a/nntp.js
+++ b/nntp.js
@@ -2,6 +2,7 @@
  *  TODO: - keepalive timer (< 3 min intervals)
  *        - TLS support (port 563)
  */
+ 
 
 var util = require('util'),
     net = require('net'),


### PR DESCRIPTION
Hello,
I've been experimenting with your node-nntp library and I was running into issues with posting messages to a server. After spending a lot of time going through your code and debugging things, it seemed as though it had to do with the way that the send queue was working. What I observed is that I would queue up a message to post with the POST command, but it would include the message callback function in the same object when put on the queue. When it executed this, it would do the POST first but then shift the entire instruction off of the queue. When the app received the 340 - Ok to post message and then tried to send up the message, it was already shifted off of the queue and the message wouldn't get posted.

My fix was to add a condition, and if it was a post instruction, don't shift it off the queue until we receive the 340 response and actually post the message.

I"m fairly new to Node.js so my solution may cause issues with multiple requests coming in, but it does work to successfully post a message now. If you have any feedback, or would like me to make any other changes then I'd love to hear it. Or if there was no actual issue and I was missing something initially, then please let me know what I was doing wrong with posting messages.

Thanks!
Kevin
