### PR TITLE
When debug is off, line 662 in function NNTP.prototype._send gave an error

### DIFF
--- a/lib/nntp.js
+++ b/lib/nntp.js
@@ -659,7 +659,9 @@ NNTP.prototype._send = function(cmd, params, cb) {
     this._curReq = this._queue.shift();
     this._socket.write(this._curReq.cmd);
     if (this._curReq.params !== undefined) {
-      this._debug('> ' + this._curReq.cmd + ' ' + this._curReq.params);
+      if (this._debug) {
+        this._debug('> ' + this._curReq.cmd + ' ' + this._curReq.params);
+      }
       this._socket.write(' ');
       this._socket.write(''+this._curReq.params);
     } else if (this._debug)


### PR DESCRIPTION
NNTP.prototype._debug is called as a function, while it is a boolean.
NNTP.prototype._debug is now tested as a boolean first on line 662
