### PR TITLE
Make stream conversion possible to other encoding

### DIFF
--- a/lib/nntp.js
+++ b/lib/nntp.js
@@ -277,7 +277,7 @@ NNTP.prototype.connect = function(options) {
     if (isErr || !chunk)
       return;
     if (self._stream === undefined)
-      self._buffer += chunk.toString(self._bufferEnc || 'utf8', start, end);
+      self._buffer += chunk.toString(self._bufferEnc || 'binary', start, end);
     else
       self._stream.emit('data', chunk.slice(start, end));
   }


### PR DESCRIPTION
Converting buffers to other encodings than utf-8 is impossible if
you already encode it right after receiving the chunk. I for example
read a lot of articles encoded in ISO-8859-1 which I cannot convert
(with node-iconv) to UTF-8 anymore.
