### PR TITLE
Pass servername to TLS

### DIFF
--- a/lib/nntp.js
+++ b/lib/nntp.js
@@ -162,7 +162,7 @@ NNTP.prototype.connect = function(options) {
   var socket = this._socket = new Socket();
   this._socket.setTimeout(0);
   if (this.options.secure)
-    socket = tls.connect({ socket: this._socket }, onconnect);
+    socket = tls.connect({ socket: this._socket, servername:this.options.host }, onconnect);
   else
     this._socket.once('connect', onconnect);
   function onconnect() {


### PR DESCRIPTION
Fixes error: 
  
    Error: Hostname/IP doesn't match certificate's altnames: "Host: null. is not in the cert's altnames:......

When passing a socket to tls.connect, the host is ignored and stops the certificate being matched.