### PR TITLE
fix typeerror because _debug is boolean

### DIFF
--- a/lib/nntp.js
+++ b/lib/nntp.js
@@ -659,12 +659,12 @@ NNTP.prototype._send = function(cmd, params, cb) {
     this._curReq = this._queue.shift();
     this._socket.write(this._curReq.cmd);
     if (this._curReq.params !== undefined) {
-      if (this._debug) {
+      if (typeof(this._debug) === 'function') {
         this._debug('> ' + this._curReq.cmd + ' ' + this._curReq.params);
       }
       this._socket.write(' ');
       this._socket.write(''+this._curReq.params);
-    } else if (this._debug)
+    } else if (typeof(this._debug) === 'function')
       this._debug('> ' + this._curReq.cmd);
       
     this._socket.write(B_CRLF);


### PR DESCRIPTION
The lib did not work out of the box because `_debug` was `false` in my case.
This fixes the problem by checking if `_debug` is a `function` before calling it.