### PR TITLE
fix _send invocation in post method

### DIFF
--- a/lib/nntp.js
+++ b/lib/nntp.js
@@ -611,7 +611,7 @@ NNTP.prototype.groupsDesc = function(search, cb) {
 
 NNTP.prototype.post = function(msg, cb) {
   var self = this, composing = true;
-  this._send('POST', function reentry(err, code, r, type) {
+  this._send('POST', undefined, function reentry(err, code, r, type) {
     if (err || !composing)
       return cb(err);
 


### PR DESCRIPTION
the `_send` method takes three arguments, where the second is params, and the third the cb.
this was wrong in the `post` method, causing `post` to send the contents of the callback function to the nntp server.